### PR TITLE
Remove redundant GitHub login URI part

### DIFF
--- a/src/components/PreviewDialog.vue
+++ b/src/components/PreviewDialog.vue
@@ -87,21 +87,13 @@
       },
       genGithubUrl () {
         const body = generateMarkdown(this.genTransformedIssue())
-        const returnUrl = format({
+        this.githubUrl = format({
           protocol: 'https',
           host: 'github.com',
           pathname: this.issue.repository.url,
           query: {
             title: this.issueTitle,
             body,
-          },
-        })
-        this.githubUrl = format({
-          protocol: 'https',
-          host: 'github.com',
-          pathname: '/login',
-          query: {
-            return_to: returnUrl,
           },
         })
       },


### PR DESCRIPTION
Fixes #46.

Prepending `https://github.com/login?return_to=` does seem redundant since GitHub has changed routing logic on their part: now when user directly enters url to issue form, they only get redirected to `login` when they are not authenticated at GitHub, and otherwise - they just get to see issue form without trouble.

But when you attend `https://github.com/login?return_to=...` it seems to internally redirect to "Email settings" screen for loggen in user. One fact that users barely report that doesn't mean it didn't happen a lot of times. This commit is going to fix it once and for all.